### PR TITLE
[#15] Fix bug in the mapping of types between sqlalchemy and JTS

### DIFF
--- a/jtssql/helpers.py
+++ b/jtssql/helpers.py
@@ -105,8 +105,9 @@ def restore_schema(prefix, table, columns, constraints):  # noqa
     fields = []
     for column in columns:
         try:
-            field_type = mapping[column.type.__class__]
-        except KeyError:
+            field_type = [value for col_type, value in mapping.items()
+                          if isinstance(column.type, col_type)][0]
+        except IndexError:
             message = 'Type %s is not supported' % column.type
             raise TypeError(message)
         field = {'name': column.name, 'type': field_type}


### PR DESCRIPTION
SQLAlchemy use different classes for the types used in different databases. For
example, a textual type in Oracle is named CLOB. They're all textual, though,
and inherit from `sqlalchemy.sql.sqltypes.Text`, so instead of checking that
the type has the same class as `sqlalchemy.sql.sqltypes.Text`, we also allow
subclasses.
