### PR TITLE
fix call to join - TypeError: join() takes exactly one argument (2 given)

### DIFF
--- a/jsontableschema_sql/storage.py
+++ b/jsontableschema_sql/storage.py
@@ -233,7 +233,7 @@ class Storage(object):
         # Prepare name
         tablename = mappers.bucket_to_tablename(self.__prefix, bucket)
         if self.__dbschema:
-            tablename = '.'.join(self.__dbschema, tablename)
+            tablename = '.'.join((self.__dbschema, tablename))
 
         return self.__metadata.tables[tablename]
 


### PR DESCRIPTION
2017-01-02T15:48:21.242711765Z   File "/usr/local/lib/python2.7/dist-packages/jsontableschema_sql/storage.py", line 203, in write
2017-01-02T15:48:21.242716862Z     table = self.__get_table(bucket)
2017-01-02T15:48:21.242721760Z   File "/usr/local/lib/python2.7/dist-packages/jsontableschema_sql/storage.py", line 236, in __get_table
2017-01-02T15:48:21.242726957Z     tablename = '.'.join(self.__dbschema, tablename)
2017-01-02T15:48:21.242731855Z TypeError: join() takes exactly one argument (2 given)