### PR TITLE
Allow updating storage using 'update keys'

### DIFF
--- a/data/original.csv
+++ b/data/original.csv
@@ -1,0 +1,5 @@
+person_id,name,favorite_color
+1,ulysses,blue
+2,theseus,green
+3,perseus,red
+4,dedalus,yellow

--- a/data/original.json
+++ b/data/original.json
@@ -1,0 +1,25 @@
+
+{
+    "primaryKey": "person_id",
+    "fields": [
+        {
+            "name": "person_id",
+            "type": "integer",
+            "constraints": {
+                "required": true
+            }
+        },
+        {
+            "name": "name",
+            "type": "string",
+            "constraints": {
+                "required": true
+            }
+        },
+        {
+            "name": "favorite_color",
+            "type": "string"
+        }
+
+    ]
+}

--- a/data/update.csv
+++ b/data/update.csv
@@ -1,0 +1,6 @@
+person_id,name,favorite_color
+5,apollo,orange
+3,perseus,magenta
+6,zeus,grey
+4,dedalus,sunshine
+5,apollo,peach

--- a/jsontableschema_sql/writer.py
+++ b/jsontableschema_sql/writer.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import json
+
+import pybloom_live
+from sqlalchemy import select
+
+import jsontableschema
+from jsontableschema.exceptions import InvalidObjectType
+
+
+BUFFER_SIZE = 1000
+
+
+class StorageWriter(object):
+
+    def __init__(self, table, descriptor, update_keys):
+
+        self.table = table
+        self.descriptor = descriptor
+        self.update_keys = update_keys
+        if update_keys is not None:
+            self.__prepare_bloom()
+        self.__buffer = []
+
+    def write(self, rows, keyed):
+        # Prepare
+        schema = jsontableschema.Schema(self.descriptor)
+
+        # Write
+        for row in rows:
+            if not keyed:
+                row = self.__convert_to_keyed(schema, row)
+
+            keyed_row = row
+
+            if self.__check_existing(keyed_row):
+                self.__insert()
+                if self.__update(row):
+                    continue
+
+            self.__buffer.append(keyed_row)
+
+            if len(self.__buffer) > BUFFER_SIZE:
+                self.__insert()
+            yield keyed_row
+
+        self.__insert()
+
+    def __insert(self):
+        if len(self.__buffer) > 0:
+            # Insert data
+            self.table.insert().execute(self.__buffer)
+            # Clean memory
+            self.__buffer = []
+
+    def __update(self, row):
+        expr = self.table.update().values(row)
+        for key in self.update_keys:
+            expr = expr.where(getattr(self.table.c, key) == row[key])
+        res = expr.execute()
+        return res.rowcount > 0
+
+    @staticmethod
+    def __convert_to_keyed(schema, row):
+        keyed_row = {}
+        for index, field in enumerate(schema.fields):
+            value = row[index]
+            try:
+                value = field.cast_value(value)
+            except InvalidObjectType:
+                value = json.loads(value)
+            keyed_row[field.name] = value
+
+        return keyed_row
+
+    def __prepare_bloom(self):
+        self.bloom = pybloom_live.ScalableBloomFilter()
+        columns = [getattr(self.table.c, key) for key in self.update_keys]
+        keys = select(columns).execution_options(stream_results=True).execute()
+        for key in keys:
+            self.bloom.add(key)
+
+    def __check_existing(self, row):
+        if self.update_keys is not None:
+            key = tuple(row[key] for key in self.update_keys)
+            if key in self.bloom:
+                return True
+            else:
+                self.bloom.add(key)
+                return False
+        else:
+            return False

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ INSTALL_REQUIRES = [
     'sqlalchemy>=1.0,<2.0a',
     'jsontableschema>=0.7,<1.0a',
     'tabulator>=0.7,<1.0a',
+    'pybloom_live==2.2.0'
 ]
 TESTS_REQUIRE = [
     'pylama',


### PR DESCRIPTION
- fixes #31 

---

The update keys are used to identify already existing rows which should be updated.
We make use of a bloom filter to avoid hitting the DB for every row - 
the bloom filter gives us a definite answer for missing rows, and a 99% certainity for existing rows.