### PR TITLE
Fix bug with generators + update, modify generator API

### DIFF
--- a/jsontableschema_sql/writer.py
+++ b/jsontableschema_sql/writer.py
@@ -8,12 +8,14 @@ import json
 
 import pybloom_live
 from sqlalchemy import select
+from collections import namedtuple
 
 import jsontableschema
 from jsontableschema.exceptions import InvalidObjectType
 
 
 BUFFER_SIZE = 1000
+WrittenRow = namedtuple('WrittenRow', ['row', 'updated'])
 
 
 class StorageWriter(object):
@@ -41,13 +43,14 @@ class StorageWriter(object):
             if self.__check_existing(keyed_row):
                 self.__insert()
                 if self.__update(row):
+                    yield WrittenRow(keyed_row, True)
                     continue
 
             self.__buffer.append(keyed_row)
 
             if len(self.__buffer) > BUFFER_SIZE:
                 self.__insert()
-            yield keyed_row
+            yield WrittenRow(keyed_row, False)
 
         self.__insert()
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -102,7 +102,10 @@ def test_update():
 
     # Write data to buckets
     storage.write('colors', original_rows, update_keys=update_keys)
-    storage.write('colors', update_rows, update_keys=update_keys)
+    gen = storage.write('colors', update_rows, update_keys=update_keys, as_generator=True)
+    gen = list(gen)
+    assert len(gen) == 5
+    assert len(list(filter(lambda i: i.updated, gen))) == 3
 
     # Create new storage to use reflection only
     storage = Storage(engine=engine, prefix='test_update_')


### PR DESCRIPTION
This PR fixes a small bug I introduced (updated rows weren't returned via the generator).
Also, I'm modifying the way the generator works - instead of just pushing the data, push the row and some metadata via a `namedtuple`.
This is in preparation for the next PR which will introduce `autoincrement` fields.