### PR TITLE
Make update work with long scalar values

### DIFF
--- a/tableschema_sql/writer.py
+++ b/tableschema_sql/writer.py
@@ -60,7 +60,7 @@ class Writer(object):
         columns = [getattr(self.__table.c, key) for key in self.__update_keys]
         keys = select(columns).execution_options(stream_results=True).execute()
         for key in keys:
-            self.__bloom.add(key)
+            self.__bloom.add(tuple(key))
 
     def __insert(self):
         """Insert rows to table


### PR DESCRIPTION
When building the bloom filter, we used to use the results coming from sqlalchemy directly.
Turns out that these objects are of type `sqlalchemy.engine.result.RowProxy`, which for long values truncate the data inside them when converted to string using `str` (which is exactly what `pybloom` does before hashing).
This causes wrong data to be stored in the bloom filter, causing inserts for existing rows.