### PR TITLE
Add Travis Python 3.7 Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo:
   false
 
@@ -14,7 +15,7 @@ python:
   - 2.7
   - 3.5
   - 3.6
-  # - 3.7
+  - 3.7
 
 env:
   global:


### PR DESCRIPTION
This fixes the travis ci config to use the xenial distribution
which allows for Python 3.7 testing.

Signed-off-by: David Brown <dmlb2000@gmail.com>