### PR TITLE
Add option to configure buffer size, bloom filter use

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ This driver provides an additional API:
 - `keyed (bool)` - accept keyed rows
 - `as_generator (bool)` - returns generator to provide writing control to the client
 - `update_keys (str[])` - update instead of inserting if key values match existent rows
+- `buffer_size (int=1000)` - maximum number of rows to try and write to the db in one batch
+- `use_bloom_filter (bool=True)` - should we use a bloom filter to optimize DB update performance (in exchange for some setup time)
 
 ## Contributing
 

--- a/tableschema_sql/storage.py
+++ b/tableschema_sql/storage.py
@@ -188,7 +188,8 @@ class Storage(tableschema.Storage):
         rows = list(self.iter(bucket))
         return rows
 
-    def write(self, bucket, rows, keyed=False, as_generator=False, update_keys=None, buffer_size=1000):
+    def write(self, bucket, rows, keyed=False, as_generator=False, update_keys=None,
+              buffer_size=1000, use_bloom_filter=True):
         """https://github.com/frictionlessdata/tableschema-sql-py#storage
         """
 
@@ -210,7 +211,8 @@ class Storage(tableschema.Storage):
             autoincrement=autoincrement if self.__dialect in ['postgresql'] else None,
             update_keys=update_keys,
             convert_row=convert_row,
-            buffer_size=buffer_size)
+            buffer_size=buffer_size,
+            use_bloom_filter=use_bloom_filter)
         with self.__connection.begin():
             gen = writer.write(rows, keyed=keyed)
             if as_generator:

--- a/tableschema_sql/storage.py
+++ b/tableschema_sql/storage.py
@@ -188,7 +188,7 @@ class Storage(tableschema.Storage):
         rows = list(self.iter(bucket))
         return rows
 
-    def write(self, bucket, rows, keyed=False, as_generator=False, update_keys=None):
+    def write(self, bucket, rows, keyed=False, as_generator=False, update_keys=None, buffer_size=1000):
         """https://github.com/frictionlessdata/tableschema-sql-py#storage
         """
 
@@ -209,7 +209,8 @@ class Storage(tableschema.Storage):
             # Only PostgreSQL supports "returning" so we don't use autoincrement for all
             autoincrement=autoincrement if self.__dialect in ['postgresql'] else None,
             update_keys=update_keys,
-            convert_row=convert_row)
+            convert_row=convert_row,
+            buffer_size=buffer_size)
         with self.__connection.begin():
             gen = writer.write(rows, keyed=keyed)
             if as_generator:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -319,7 +319,13 @@ def test_storage_write_generator():
     assert storage.read('comments') == cast(COMMENTS)['data']
 
 
-def test_storage_update():
+@pytest.mark.parametrize('use_bloom_filter, buffer_size', [
+    (True, 1000),
+    (False, 1000),
+    (True, 2),
+    (False, 1),
+])
+def test_storage_update(use_bloom_filter, buffer_size):
     RESOURCE = {
         'schema': {
             'fields': [
@@ -359,7 +365,8 @@ def test_storage_update():
     # Write data to buckets
     storage.write('colors', RESOURCE['data'], update_keys=update_keys)
     gen = storage.write('colors', RESOURCE['updateData'],
-        update_keys=update_keys, as_generator=True)
+        update_keys=update_keys, as_generator=True,
+        use_bloom_filter=use_bloom_filter, buffer_size=buffer_size)
     gen = list(gen)
     assert len(gen) == 5
     assert len(list(filter(lambda i: i.updated, gen))) == 3
@@ -368,7 +375,8 @@ def test_storage_update():
     # Reflect storage
     storage = Storage(engine=engine, prefix='test_update_', autoincrement='__id')
     gen = storage.write('colors', RESOURCE['updateData'],
-        update_keys=update_keys, as_generator=True)
+        update_keys=update_keys, as_generator=True,
+        use_bloom_filter=use_bloom_filter, buffer_size=buffer_size)
     gen = list(gen)
     assert len(gen) == 5
     assert len(list(filter(lambda i: i.updated, gen))) == 5
@@ -394,9 +402,11 @@ def test_storage_update():
     storage = Storage(engine=engine, prefix='test_update_')
     storage.delete()
     storage.create('colors', RESOURCE['schema'])
-    storage.write('colors', RESOURCE['data'], update_keys=update_keys)
+    storage.write('colors', RESOURCE['data'], update_keys=update_keys,
+                  use_bloom_filter=use_bloom_filter, buffer_size=buffer_size)
     gen = storage.write('colors', RESOURCE['updateData'],
-        update_keys=update_keys, as_generator=True)
+        update_keys=update_keys, as_generator=True,
+        use_bloom_filter=use_bloom_filter, buffer_size=buffer_size)
     gen = list(gen)
     assert len(gen) == 5
     assert len(list(filter(lambda i: i.updated, gen))) == 3


### PR DESCRIPTION
When working in streaming scenarios, the buffer size and bloom filter affect the stream's responsiveness greatly.
In this PR we expose these two parameters so that the user might fine tune them based on the exact application's needs.