### PR TITLE
Automatically add regex support to sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,18 +132,6 @@ Here described only breaking and the most important changes. The full changelog 
 
 - Implemented constraints loading to a database
 
-##### Adding regular expression support to sqlite:
-```python
-import re
-
-def regexp(expr, item):
-  reg = re.compile(expr)
-  return reg.search(item) is not None
-
-conn = engine.connect()
-conn.connection.create_function("REGEXP", 2, regexp)
-```
-
 #### v1.2
 
 - Add option to configure buffer size, bloom filter use (#77)

--- a/tableschema_sql/storage.py
+++ b/tableschema_sql/storage.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 import collections
 from functools import partial
 
+import re
 import six
 import sqlalchemy
 import tableschema
@@ -35,6 +36,14 @@ class Storage(tableschema.Storage):
         self.__autoincrement = autoincrement
         self.__only = reflect_only or (lambda _: True)
         self.__dialect = engine.dialect.name
+
+        # Added regex support to sqlite
+        if self.__dialect == 'sqlite':
+            def regexp(expr, item):
+                reg = re.compile(expr)
+                return reg.search(item) is not None
+            # It will fail silently if this function already exists
+            self.__connection.connection.create_function('REGEXP', 2, regexp)
 
         # Create mapper
         self.__mapper = Mapper(prefix=prefix, dialect=self.__dialect)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -587,15 +587,6 @@ def test_storage_constraints(dialect, database_url):
 
     # Create table
     engine = create_engine(database_url)
-
-    if dialect == 'sqlite':
-        import re
-        def regexp(expr, item):
-            reg = re.compile(expr)
-            return reg.search(item) is not None
-        conn = engine.connect()
-        conn.connection.create_function('REGEXP', 2, regexp)
-
     storage = Storage(engine, prefix='test_storage_constraints_')
     storage.create('bucket', schema, force=True)
     table_name = 'test_storage_constraints_bucket'


### PR DESCRIPTION
- connects #84

---

@akariv 
After your discovery of the `create_function` I don't see a reason why we can't ensure that it exists internally. Otherwise, I think some people will run into problems loading their data packages to SQL (which use the pattern constraint). I hope we can simplify clients' life with this PR. WDYT?

---

Please preserve this line to notify @roll (lead of this repository)
