### PR TITLE
Import Package in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ pip install tableschema-sql
 ## Documentation
 
 ```python
+from datapackage import Package 
 from tableschema import Table
 from sqlalchemy import create_engine
 


### PR DESCRIPTION
# Overview

The [example in the README](https://github.com/frictionlessdata/datapackage-pipelines-sql-driver#documentation) _as is_ creates the following error:

    NameError: name 'Package' is not defined

Adding `from frictionless import Package` gets you one step further, but then has:

    AttributeError: 'Package' object has no attribute 'save'

Using the older `from datapackage import Package` does not generate errors (hence this PR). But the whole example should probably be updated to work with frictionless-py.

---

Please preserve this line to notify @roll (lead of this repository)
